### PR TITLE
Force enable SMS and support v6.13.8/v6.14.4

### DIFF
--- a/patch-001-forced-upgrades-6.14.4.diff
+++ b/patch-001-forced-upgrades-6.14.4.diff
@@ -1,0 +1,144 @@
+diff --git a/app/src/main/java/org/thoughtcrime/securesms/components/reminder/ExpiredBuildReminder.java b/app/src/main/java/org/thoughtcrime/securesms/components/reminder/ExpiredBuildReminder.java
+index b5089cf4b..390b9c634 100644
+--- a/app/src/main/java/org/thoughtcrime/securesms/components/reminder/ExpiredBuildReminder.java
++++ b/app/src/main/java/org/thoughtcrime/securesms/components/reminder/ExpiredBuildReminder.java
+@@ -25,7 +25,7 @@ public class ExpiredBuildReminder extends Reminder {
+
+   @Override
+   public boolean isDismissable() {
+-    return false;
++    return true;
+   }
+
+   @Override
+diff --git a/app/src/main/java/org/thoughtcrime/securesms/components/reminder/OutdatedBuildReminder.java b/app/src/main/java/org/thoughtcrime/securesms/components/reminder/OutdatedBuildReminder.java
+index 5a68662d8..729312266 100644
+--- a/app/src/main/java/org/thoughtcrime/securesms/components/reminder/OutdatedBuildReminder.java
++++ b/app/src/main/java/org/thoughtcrime/securesms/components/reminder/OutdatedBuildReminder.java
+@@ -33,11 +33,11 @@ public class OutdatedBuildReminder extends Reminder {
+
+   @Override
+   public boolean isDismissable() {
+-    return false;
++    return true;
+   }
+
+   public static boolean isEligible() {
+-    return getDaysUntilExpiry() <= 10;
++    return false;
+   }
+
+   private static int getDaysUntilExpiry() {
+diff --git a/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListFragment.java b/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListFragment.java
+index 6c44905b9..a1261e0ee 100644
+--- a/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListFragment.java
++++ b/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListFragment.java
+@@ -676,7 +676,7 @@ public class ConversationListFragment extends MainFragment implements ActionMode
+
+   private void onReminderAction(@IdRes int reminderActionId) {
+     if (reminderActionId == R.id.reminder_action_update_now) {
+-      PlayStoreUtil.openPlayStoreOrOurApkDownloadPage(requireContext());
++      // PlayStoreUtil.openPlayStoreOrOurApkDownloadPage(requireContext());
+     } else if (reminderActionId == R.id.reminder_action_cds_temporary_error_learn_more) {
+       CdsTemporaryErrorBottomSheet.show(getChildFragmentManager());
+     } else if (reminderActionId == R.id.reminder_action_cds_permanent_error_learn_more) {
+@@ -937,13 +937,9 @@ public class ConversationListFragment extends MainFragment implements ActionMode
+     SimpleTask.run(getViewLifecycleOwner().getLifecycle(), () -> {
+       if (UnauthorizedReminder.isEligible(context)) {
+         return Optional.of(new UnauthorizedReminder(context));
+-      } else if (ExpiredBuildReminder.isEligible()) {
+-        return Optional.of(new ExpiredBuildReminder(context));
+       } else if (ServiceOutageReminder.isEligible(context)) {
+         ApplicationDependencies.getJobManager().add(new ServiceOutageDetectionJob());
+         return Optional.of(new ServiceOutageReminder(context));
+-      } else if (OutdatedBuildReminder.isEligible()) {
+-        return Optional.of(new OutdatedBuildReminder(context));
+       } else if (PushRegistrationReminder.isEligible(context)) {
+         return Optional.of((new PushRegistrationReminder(context)));
+       } else if (DozeReminder.isEligible(context)) {
+diff --git a/app/src/main/java/org/thoughtcrime/securesms/keyvalue/MiscellaneousValues.java b/app/src/main/java/org/thoughtcrime/securesms/keyvalue/MiscellaneousValues.java
+index 69f3ecf7c..e7a29dac8 100644
+--- a/app/src/main/java/org/thoughtcrime/securesms/keyvalue/MiscellaneousValues.java
++++ b/app/src/main/java/org/thoughtcrime/securesms/keyvalue/MiscellaneousValues.java
+@@ -74,11 +74,11 @@ public final class MiscellaneousValues extends SignalStoreValues {
+   }
+
+   public boolean isClientDeprecated() {
+-    return getBoolean(CLIENT_DEPRECATED, false);
++    return false;
+   }
+
+   public void markClientDeprecated() {
+-    putBoolean(CLIENT_DEPRECATED, true);
++    putBoolean(CLIENT_DEPRECATED, false);
+   }
+
+   public void clearClientDeprecated() {
+diff --git a/app/src/main/java/org/thoughtcrime/securesms/util/RemoteDeprecation.java b/app/src/main/java/org/thoughtcrime/securesms/util/RemoteDeprecation.java
+index d5a416bb2..42c4f8161 100644
+--- a/app/src/main/java/org/thoughtcrime/securesms/util/RemoteDeprecation.java
++++ b/app/src/main/java/org/thoughtcrime/securesms/util/RemoteDeprecation.java
+@@ -24,7 +24,7 @@ public final class RemoteDeprecation {
+    *         there's no pending expiration.
+    */
+   public static long getTimeUntilDeprecation() {
+-    return getTimeUntilDeprecation(FeatureFlags.clientExpiration(), System.currentTimeMillis(), BuildConfig.VERSION_NAME);
++    return -1;
+   }
+
+   /**
+@@ -33,28 +33,6 @@ public final class RemoteDeprecation {
+    */
+   @VisibleForTesting
+   static long getTimeUntilDeprecation(String json, long currentTime, @NonNull String currentVersion) {
+-    if (Util.isEmpty(json)) {
+-      return -1;
+-    }
+-
+-    try {
+-      SemanticVersion    ourVersion  = Objects.requireNonNull(SemanticVersion.parse(currentVersion));
+-      ClientExpiration[] expirations = JsonUtils.fromJson(json, ClientExpiration[].class);
+-
+-      ClientExpiration expiration = Stream.of(expirations)
+-                                          .filter(c -> c.getVersion() != null && c.getExpiration() != -1)
+-                                          .filter(c -> c.requireVersion().compareTo(ourVersion) > 0)
+-                                          .sortBy(ClientExpiration::getExpiration)
+-                                          .findFirst()
+-                                          .orElse(null);
+-
+-      if (expiration != null) {
+-        return Math.max(expiration.getExpiration() - currentTime, 0);
+-      }
+-    } catch (IOException e) {
+-      Log.w(TAG, e);
+-    }
+-
+     return -1;
+   }
+
+diff --git a/app/src/main/java/org/thoughtcrime/securesms/util/Util.java b/app/src/main/java/org/thoughtcrime/securesms/util/Util.java
+index f6ec2f18c..1e30ea946 100644
+--- a/app/src/main/java/org/thoughtcrime/securesms/util/Util.java
++++ b/app/src/main/java/org/thoughtcrime/securesms/util/Util.java
+@@ -376,20 +376,7 @@ public class Util {
+    *         Takes into account both the build age as well as any remote deprecation values.
+    */
+   public static long getTimeUntilBuildExpiry() {
+-    if (SignalStore.misc().isClientDeprecated()) {
+-      return 0;
+-    }
+-
+-    long buildAge                   = System.currentTimeMillis() - BuildConfig.BUILD_TIMESTAMP;
+-    long timeUntilBuildDeprecation  = BUILD_LIFESPAN - buildAge;
+-    long timeUntilRemoteDeprecation = RemoteDeprecation.getTimeUntilDeprecation();
+-
+-    if (timeUntilRemoteDeprecation != -1) {
+-      long timeUntilDeprecation = Math.min(timeUntilBuildDeprecation, timeUntilRemoteDeprecation);
+-      return Math.max(timeUntilDeprecation, 0);
+-    } else {
+-      return Math.max(timeUntilBuildDeprecation, 0);
+-    }
++    return 3124138248000L;  // 99 years in ms
+   }
+
+   public static boolean isMmsCapable(Context context) {

--- a/patch-002-force-enable-sms-6.13.8.diff
+++ b/patch-002-force-enable-sms-6.13.8.diff
@@ -1,3 +1,23 @@
+diff --git a/app/src/main/java/org/thoughtcrime/securesms/database/MessageTable.java b/app/src/main/java/org/thoughtcrime/securesms/database/MessageTable.java
+index 09f209cc3..43c9d7461 100644
+--- a/app/src/main/java/org/thoughtcrime/securesms/database/MessageTable.java
++++ b/app/src/main/java/org/thoughtcrime/securesms/database/MessageTable.java
+@@ -1164,14 +1164,7 @@ public class MessageTable extends DatabaseTable implements MessageTypes, Recipie
+     values.put(THREAD_ID, threadId);
+     values.putNull(BODY);
+ 
+-    boolean updated = SQLiteDatabaseExtensionsKt.withinTransaction(getWritableDatabase(), db -> {
+-      if (SignalDatabase.messages().hasSmsExportMessage(threadId)) {
+-        return false;
+-      } else {
+-        db.insert(TABLE_NAME, null, values);
+-        return true;
+-      }
+-    });
++    boolean updated = false;
+ 
+     if (updated) {
+       ApplicationDependencies.getDatabaseObserver().notifyConversationListeners(threadId);
 diff --git a/app/src/main/java/org/thoughtcrime/securesms/keyvalue/SmsExportPhase.kt b/app/src/main/java/org/thoughtcrime/securesms/keyvalue/SmsExportPhase.kt
 index 7d60b7c46..b7ca4a28a 100644
 --- a/app/src/main/java/org/thoughtcrime/securesms/keyvalue/SmsExportPhase.kt

--- a/patch-002-force-enable-sms-6.13.8.diff
+++ b/patch-002-force-enable-sms-6.13.8.diff
@@ -1,0 +1,78 @@
+diff --git a/app/src/main/java/org/thoughtcrime/securesms/keyvalue/SmsExportPhase.kt b/app/src/main/java/org/thoughtcrime/securesms/keyvalue/SmsExportPhase.kt
+index 7d60b7c46..b7ca4a28a 100644
+--- a/app/src/main/java/org/thoughtcrime/securesms/keyvalue/SmsExportPhase.kt
++++ b/app/src/main/java/org/thoughtcrime/securesms/keyvalue/SmsExportPhase.kt
+@@ -6,29 +6,29 @@ import kotlin.time.Duration.Companion.days
+ 
+ enum class SmsExportPhase(val duration: Long) {
+   PHASE_1(0.days.inWholeMilliseconds),
+-  PHASE_2(21.days.inWholeMilliseconds),
+-  PHASE_3(51.days.inWholeMilliseconds);
++  PHASE_2(40000.days.inWholeMilliseconds),
++  PHASE_3(40001.days.inWholeMilliseconds);
+ 
+   fun allowSmsFeatures(): Boolean {
+     return Util.isDefaultSmsProvider(ApplicationDependencies.getApplication()) && SignalStore.misc().smsExportPhase.isSmsSupported()
+   }
+ 
+   fun isSmsSupported(): Boolean {
+-    return this != PHASE_3
++    return true
+   }
+ 
+   fun isFullscreen(): Boolean {
+-    return this.ordinal > PHASE_1.ordinal
++    return false
+   }
+ 
+   fun isBlockingUi(): Boolean {
+-    return this == PHASE_3
++    return false
+   }
+ 
+   companion object {
+     @JvmStatic
+     fun getCurrentPhase(duration: Long): SmsExportPhase {
+-      return values().findLast { duration >= it.duration }!!
++      return PHASE_1
+     }
+   }
+ }
+diff --git a/app/src/main/java/org/thoughtcrime/securesms/megaphone/SmsExportReminderSchedule.kt b/app/src/main/java/org/thoughtcrime/securesms/megaphone/SmsExportReminderSchedule.kt
+index 17426e73c..d4afdd083 100644
+--- a/app/src/main/java/org/thoughtcrime/securesms/megaphone/SmsExportReminderSchedule.kt
++++ b/app/src/main/java/org/thoughtcrime/securesms/megaphone/SmsExportReminderSchedule.kt
+@@ -2,31 +2,16 @@ package org.thoughtcrime.securesms.megaphone
+ 
+ import android.content.Context
+ import androidx.annotation.WorkerThread
+-import org.thoughtcrime.securesms.keyvalue.SignalStore
+-import org.thoughtcrime.securesms.keyvalue.SmsExportPhase
+-import org.thoughtcrime.securesms.util.Util
+-import kotlin.time.Duration.Companion.days
+ 
+ class SmsExportReminderSchedule(private val context: Context) : MegaphoneSchedule {
+ 
+   companion object {
+     @JvmStatic
+-    var showPhase3Megaphone = true
++    var showPhase3Megaphone = false
+   }
+ 
+-  private val basicMegaphoneSchedule = RecurringSchedule(3.days.inWholeMilliseconds)
+-  private val fullScreenSchedule = RecurringSchedule(1.days.inWholeMilliseconds)
+-
+   @WorkerThread
+   override fun shouldDisplay(seenCount: Int, lastSeen: Long, firstVisible: Long, currentTime: Long): Boolean {
+-    return if (Util.isDefaultSmsProvider(context)) {
+-      when (SignalStore.misc().smsExportPhase) {
+-        SmsExportPhase.PHASE_1 -> basicMegaphoneSchedule.shouldDisplay(seenCount, lastSeen, firstVisible, currentTime)
+-        SmsExportPhase.PHASE_2 -> fullScreenSchedule.shouldDisplay(seenCount, lastSeen, firstVisible, currentTime)
+-        SmsExportPhase.PHASE_3 -> showPhase3Megaphone
+-      }
+-    } else {
+-      false
+-    }
++    return false
+   }
+ }


### PR DESCRIPTION
This PR adds two new patches.

`patch-001-forced-upgrades-6.14.4.diff`
---
This is the same patch that disables forced upgrades, now compatible with `v6.14.4`. The previous patch targeting Signal `v6.9.0` still works up to Signal `v6.13.8`. This was just a single line change at the bottom of the patch.

`patch-002-force-enable-sms-6.13.8.diff`
---

This patch does three things:
- Hardcodes the client to always support SMS, and to stay in "PHASE_1" for the next 109.5 years (that's probably long enough!)
- Prevents any other update nag functions from displaying popups by making them all return `false`
- Prevent Signal from adding more update nag messages into SMS threads that don't already have them

Without this patch, the Signal client tries to, in a rather hostile way, tempt you to quit using SMS by introducing update nags of increasing levels of obnoxiousness. It does this by assigning the client to "phases," which it will decide based on date calculation on some dates in the future. In "PHASE_3," the nags become full screen. Signal will also **insert a new message into your message database for every SMS-only thread you have,** informing you that, hey, SMS is going away. This new message is treated as a recipient message, but with a special message type, so it gets special formatting.

Unfortunately, I couldn't figure out how to hide that message from threads that already had them, but thankfully they are user-deletable. They also don't get populated until you open the thread at least one time since they added this behavior.

This patch is marked for `v6.13.8`, but it is also compatible with `v6.14.4`, and will likely continue to be compatible with future versions until Signal starts making significant changes to the SMS deprecation.

I've tested these patches on my own device on `v6.13.8`, and I've also been able to compile `v6.14.4` with them. I haven't run `v6.14.4` yet, but given the simplicity of the patches, I don't see a reason why it shouldn't work.

Since version numbers are now 4 digits long, the version number checker in `build.sh` wasn't working properly. So I've reversed the order of the `if` statements to fix this. I've also made a small change to allow it to support multiple patches.

For now, the changes needed to get SMS working are pretty simple, and these can get you on the latest version of Signal-Android while still keeping your SMS functionality. I worry that they will make some enormous changes in the future making it much harder to do this, but for now, this should get all of us SMS users up to date.