### PR TITLE
Update for 6.15.3

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@
 set -euxo pipefail
 
 # Which versions of Signal to build APKs for
-versions="v6.5.0 v6.5.1 v6.5.2 v6.5.3 v6.5.4 v6.5.5 v6.5.6 v6.6.0 v6.6.1 v6.6.2 v6.6.3 v6.7.0 v6.7.1 v6.7.2 v6.7.3 v6.7.4 v6.7.5 v6.7.6 v6.8.0 v6.8.1 v6.8.2 v6.8.3 v6.9.0 v6.9.1 v6.9.2 v6.10.0 v6.10.1 v6.10.2 v6.10.3 v6.10.4 v6.10.5 v6.10.6 v6.10.7 v6.10.8 v6.10.9 v6.11.0 v6.11.1 v6.11.2 v6.11.3 v6.11.4 v6.11.5 v6.11.6 v6.11.7 v6.12.0 v6.12.1 v6.12.2 v6.12.3 v6.12.4 v6.12.5 v6.12.6 v6.13.0 v6.13.1 v6.13.2 v6.13.3 v6.13.4 v6.13.5 v6.13.6 v6.13.7 v6.13.8 v6.14.0 v6.14.1 v6.14.2 v6.14.3 v6.14.4"
+versions="v6.5.0 v6.5.1 v6.5.2 v6.5.3 v6.5.4 v6.5.5 v6.5.6 v6.6.0 v6.6.1 v6.6.2 v6.6.3 v6.7.0 v6.7.1 v6.7.2 v6.7.3 v6.7.4 v6.7.5 v6.7.6 v6.8.0 v6.8.1 v6.8.2 v6.8.3 v6.9.0 v6.9.1 v6.9.2 v6.10.0 v6.10.1 v6.10.2 v6.10.3 v6.10.4 v6.10.5 v6.10.6 v6.10.7 v6.10.8 v6.10.9 v6.11.0 v6.11.1 v6.11.2 v6.11.3 v6.11.4 v6.11.5 v6.11.6 v6.11.7 v6.12.0 v6.12.1 v6.12.2 v6.12.3 v6.12.4 v6.12.5 v6.12.6 v6.13.0 v6.13.1 v6.13.2 v6.13.3 v6.13.4 v6.13.5 v6.13.6 v6.13.7 v6.13.8 v6.14.0 v6.14.1 v6.14.2 v6.14.3 v6.14.4 v6.15.3"
 
 # Check that we have some of the tools installed
 which keytool
@@ -35,7 +35,9 @@ for SIGNAL_TAG in $versions; do
   # different versions need slightly different patches
   v=$(echo $SIGNAL_TAG | tr -d '.v')
 
-  if [ "$v" -gt 6139 ]; then
+  if [ "$v" -gt 6152 ]; then
+    patch="patch-001-forced-upgrades-6.14.4.diff patch-002-enable-sms-6.15.3.diff"
+  elif [ "$v" -gt 6139 ]; then
     patch="patch-001-forced-upgrades-6.14.4.diff patch-002-enable-sms-6.13.8.diff"
   elif [ "$v" -gt 6136 ]; then
     patch="patch-001-forced-upgrades-6.9.0.diff patch-002-enable-sms-6.13.8.diff"

--- a/patch-002-enable-sms-6.15.3.diff
+++ b/patch-002-enable-sms-6.15.3.diff
@@ -1,0 +1,111 @@
+diff --git a/app/src/main/java/org/thoughtcrime/securesms/database/MessageTable.kt b/app/src/main/java/org/thoughtcrime/securesms/database/MessageTable.kt
+index d4e393d79..064834d7d 100644
+--- a/app/src/main/java/org/thoughtcrime/securesms/database/MessageTable.kt
++++ b/app/src/main/java/org/thoughtcrime/securesms/database/MessageTable.kt
+@@ -1240,29 +1240,7 @@ open class MessageTable(context: Context?, databaseHelper: SignalDatabase) : Dat
+   }
+
+   fun insertSmsExportMessage(recipientId: RecipientId, threadId: Long) {
+-    val updated = writableDatabase.withinTransaction { db ->
+-      if (messages.hasSmsExportMessage(threadId)) {
+-        false
+-      } else {
+-        db.insertInto(TABLE_NAME)
+-          .values(
+-            RECIPIENT_ID to recipientId.serialize(),
+-            RECIPIENT_DEVICE_ID to 1,
+-            DATE_RECEIVED to System.currentTimeMillis(),
+-            DATE_SENT to System.currentTimeMillis(),
+-            READ to 1,
+-            TYPE to MessageTypes.SMS_EXPORT_TYPE,
+-            THREAD_ID to threadId,
+-            BODY to null
+-          )
+-          .run()
+-        true
+-      }
+-    }
+-
+-    if (updated) {
+-      ApplicationDependencies.getDatabaseObserver().notifyConversationListeners(threadId)
+-    }
++    // No :)
+   }
+
+   fun endTransaction(database: SQLiteDatabase) {
+--- a/app/src/main/java/org/thoughtcrime/securesms/keyvalue/SmsExportPhase.kt
++++ b/app/src/main/java/org/thoughtcrime/securesms/keyvalue/SmsExportPhase.kt
+@@ -6,29 +6,29 @@ import kotlin.time.Duration.Companion.days
+ 
+ enum class SmsExportPhase(val duration: Long) {
+   PHASE_1(0.days.inWholeMilliseconds),
+-  PHASE_2(21.days.inWholeMilliseconds),
+-  PHASE_3(51.days.inWholeMilliseconds);
++  PHASE_2(40000.days.inWholeMilliseconds),
++  PHASE_3(40001.days.inWholeMilliseconds);
+ 
+   fun allowSmsFeatures(): Boolean {
+     return Util.isDefaultSmsProvider(ApplicationDependencies.getApplication()) && SignalStore.misc().smsExportPhase.isSmsSupported()
+   }
+ 
+   fun isSmsSupported(): Boolean {
+-    return this != PHASE_3
++    return true
+   }
+ 
+   fun isFullscreen(): Boolean {
+-    return this.ordinal > PHASE_1.ordinal
++    return false
+   }
+ 
+   fun isBlockingUi(): Boolean {
+-    return this == PHASE_3
++    return false
+   }
+ 
+   companion object {
+     @JvmStatic
+     fun getCurrentPhase(duration: Long): SmsExportPhase {
+-      return values().findLast { duration >= it.duration }!!
++      return PHASE_1
+     }
+   }
+ }
+diff --git a/app/src/main/java/org/thoughtcrime/securesms/megaphone/SmsExportReminderSchedule.kt b/app/src/main/java/org/thoughtcrime/securesms/megaphone/SmsExportReminderSchedule.kt
+index 17426e73c..d4afdd083 100644
+--- a/app/src/main/java/org/thoughtcrime/securesms/megaphone/SmsExportReminderSchedule.kt
++++ b/app/src/main/java/org/thoughtcrime/securesms/megaphone/SmsExportReminderSchedule.kt
+@@ -2,31 +2,16 @@ package org.thoughtcrime.securesms.megaphone
+ 
+ import android.content.Context
+ import androidx.annotation.WorkerThread
+-import org.thoughtcrime.securesms.keyvalue.SignalStore
+-import org.thoughtcrime.securesms.keyvalue.SmsExportPhase
+-import org.thoughtcrime.securesms.util.Util
+-import kotlin.time.Duration.Companion.days
+ 
+ class SmsExportReminderSchedule(private val context: Context) : MegaphoneSchedule {
+ 
+   companion object {
+     @JvmStatic
+-    var showPhase3Megaphone = true
++    var showPhase3Megaphone = false
+   }
+ 
+-  private val basicMegaphoneSchedule = RecurringSchedule(3.days.inWholeMilliseconds)
+-  private val fullScreenSchedule = RecurringSchedule(1.days.inWholeMilliseconds)
+-
+   @WorkerThread
+   override fun shouldDisplay(seenCount: Int, lastSeen: Long, firstVisible: Long, currentTime: Long): Boolean {
+-    return if (Util.isDefaultSmsProvider(context)) {
+-      when (SignalStore.misc().smsExportPhase) {
+-        SmsExportPhase.PHASE_1 -> basicMegaphoneSchedule.shouldDisplay(seenCount, lastSeen, firstVisible, currentTime)
+-        SmsExportPhase.PHASE_2 -> fullScreenSchedule.shouldDisplay(seenCount, lastSeen, firstVisible, currentTime)
+-        SmsExportPhase.PHASE_3 -> showPhase3Megaphone
+-      }
+-    } else {
+-      false
+-    }
++    return false
+   }
+ }


### PR DESCRIPTION
Nothing too bad. They rewrote `MessageTable` in Kotlin so the previous patch no longer worked. This PR just modifies the patch to clear out the new Kotlin function that injects the "pls stop using SMS pretty please" message into SMS threads. The rest is unchanged.

All of the SMS-related stuff is now in Kotlin files, so I wouldn't expect any major breaking changes from Signal for quite a while now. This may even get us as far as them removing SMS support altogether instead of just disabling it. Really not looking forward to that day... but, today is not that day.

The patch that disables forced upgrades targets `.java` files, and since they're systematically rewriting the app in Kotlin, that will probably have to be updated eventually. But, there are many popular Signal forks that already disable that, so maintaining those patches won't be any work at all.